### PR TITLE
Fixed Typo that Broke Review Functionality

### DIFF
--- a/client/app/actions/rentActions.js
+++ b/client/app/actions/rentActions.js
@@ -41,6 +41,7 @@ var RentActions = {
   reviewSubmitted: function (data) { 
     RentDispatcher.dispatch({
       type: RentConstants.REVIEW_SUBMITTED,
+      load: data
     });
   },
 


### PR DESCRIPTION
I accidentally deleted a line which then broke reviews. It is fixed now.
